### PR TITLE
Add microphone.h/.c HAL module with initial implementations

### DIFF
--- a/bluetooth-speaker-app/hal/include/hal/microphone.h
+++ b/bluetooth-speaker-app/hal/include/hal/microphone.h
@@ -1,0 +1,46 @@
+#ifndef _MICROPHONE_H_
+#define _MICROPHONE_H_
+
+/*
+Explanation of each function provided by this module:
+1. microphone_init:
+    Sets up the audio input device and prepares it for listening
+    Configures any required libraries (TO BE DETERMINED LATER)
+
+2. microphone_cleanup:
+    Cleans up any allocated resources related to the microphone
+    Stops any active audio processing threads
+
+3. microphone_enable_audio_listening:
+    Starts a separate thread that continuously listens for audio input
+    Captures audio and converts it into text
+
+4. microphone_disable_audio_listening:
+    Stops the background thread that listens for audio input
+    Prevents unnecessary processing when audio input is not needed
+
+5. microphone_get_audio_input:
+    Returns the latest recorded audio input as a string (MIGHT NOT NEED THIS ONE)
+
+6. microphone_get_keyword_from_audio_input:
+    Processes the transcribed audio input string to detect specific keywords
+    Returns the first meaningful keyword detected (e.g., "stop", "next", "volume up")
+ */
+
+// Enum to provide what the user have commanded
+enum keyword {
+    KEYWORD_NONE,
+    STOP,
+    NEXT,
+    VOLUME_UP,
+    VOLUME_DOWN
+};
+
+void microphone_init(void);
+void microphone_enable_audio_listening(void);
+void microphone_disable_audio_listening(void);
+const char* microphone_get_audio_input(void);
+enum keyword microphone_get_keyword_from_audio_input(const char* audio_input);
+void microphone_cleanup(void);
+
+#endif

--- a/bluetooth-speaker-app/hal/src/microphone.c
+++ b/bluetooth-speaker-app/hal/src/microphone.c
@@ -1,0 +1,78 @@
+#include <microphone.h>
+
+#include <assert.h>
+#include <pthread.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#define MAX_INPUT 2048
+
+static char audio_input[MAX_INPUT]; // Stores the raw input from the microphone
+static bool is_mic_initialized = false;
+static bool is_mic_enabled = false;
+static pthread_t mic_thread;
+
+static void* listen_for_audio(void* arg) {
+    (void)arg;
+
+    while (is_mic_enabled) {
+        //TODO NEED TO PERFORM SPEECH TO TEXT TRANSFORMATION
+        sleep(1);
+    }
+
+    return NULL;
+}
+
+void microphone_init(void) {
+    // TODO
+    is_mic_initialized = true;
+}
+
+void microphone_enable_audio_listening(void) {
+    assert(is_mic_initialized);
+    assert(is_mic_enabled);
+    is_mic_enabled = true;
+
+    // Start a background thread to listen for audio input
+    pthread_create(&mic_thread, NULL, listen_for_audio, NULL);
+}
+
+void microphone_disable_audio_listening(void) {
+    assert(is_mic_enabled);
+    assert(is_mic_initialized);
+    is_mic_enabled = false;
+
+    // Cleans up the background thread
+    pthread_join(mic_thread, NULL);
+}
+
+const char* microphone_get_audio_input(void) {
+    // MIGHT NOT NEED THIS FUNCTION IN THE FUTURE
+    return audio_input;
+}
+
+enum keyword microphone_get_keyword_from_audio_input(const char* audio_input) {
+    assert(is_mic_initialized);
+
+    if (strstr(audio_input, "stop")) {
+        return STOP;
+    } else if (strstr(audio_input, "next song")) {
+        return NEXT;
+    } else if (strstr(audio_input, "volume up")) {
+        return VOLUME_UP;
+    } else if (strstr(audio_input, "volume down")) {
+        return VOLUME_DOWN;
+    } else {
+        return KEYWORD_NONE;
+    }
+}
+
+void microphone_cleanup(void) {
+    // TODO
+    assert(is_mic_initialized);
+    assert(!is_mic_enabled);
+    is_mic_initialized = false;
+}
+
+


### PR DESCRIPTION
Hey guys!

The added microphone.h/.c HAL module in this PR contains essential functions that this module should provide. 

It uses the thread to listen for audio input (only if audio listening is enabled); in later iterations, the module performs the audio-to-text transformation. This module also looks for specific keywords, such as stop, next song, etc., in the input audio text and provides an ENUM to distinguish among different actions requested by the user. 

Let me know if you want me to change anything for now! 

